### PR TITLE
Add aperture selector and collapsible sidebar to UnitBuilder

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,19 +3,19 @@
 
 # Windows:
 
-1. Add swing graphic and data
-2. Ad drop down for selecting window and collapsable side drawer
-3. Add scroll to sidebar
-4. Add graphic expander
-5. Fix scale display ("0.11111111111mm")
-6. Select individual frame elements.
-7. Add an UNDO!
-8. Add product/manuf filtering
-9. Add 'inside view' vs 'outside view' rotate/spin
-10. Cron-job frame-type / glass-type autoloader from AirTable
+- [ ] Add swing graphic and data
+- [ ] Change Element blocks to be inside a scrollable container so we always see the window graphic
+- [ ] Hover over frame element shows the name / ID and highlights it. Click allows direct setting (dropdown)
+- [ ] Add graphic expander
+- [ ] Fix scale display ("0.11111111111mm")
+- [ ] Select individual frame elements.
+- [ ] Add an UNDO!
+- [ ] Add product/manuf filtering
+- [ ] Add 'inside view' vs 'outside view' rotate/spin
+- [ ] Cron-job frame-type / glass-type autoloader from AirTable
 
 # Airtightness:
 
-1. Change limit from 85 to ISO 9972 limit: 250 m·K = 1,476 ft·°F (not 85!)
+- [ ] Change limit from 85 to ISO 9972 limit: 250 m·K = 1,476 ft·°F (not 85!)
 
 - https://mail.google.com/mail/u/0/#search/bcohen%40revireo.com+roberto%40elements-air.com/FMfcgzQcqtbGZHkzTGVtdxJQprLLvdWM

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,5 +1,10 @@
 # -*- Python Version: 3.11 -*-
 
+# Set test environment variables BEFORE importing any modules that depend on config
+import os
+
+os.environ.setdefault("FERNET_SECRET_KEY", "wONeDFh6szFQydAR54mE2NcXvx49PNclcovPyrTT2eM=")
+
 from typing import Callable, Generator
 
 import pytest

--- a/backend/tests/features/aperture/conftest.py
+++ b/backend/tests/features/aperture/conftest.py
@@ -1,0 +1,126 @@
+# -*- Python Version: 3.11 -*-
+"""Fixtures for aperture tests."""
+
+from typing import Generator
+
+import pytest
+from sqlalchemy.orm import Session
+
+from db_entities.aperture.aperture import Aperture
+from db_entities.aperture.aperture_element import ApertureElement
+from db_entities.aperture.aperture_frame import ApertureElementFrame
+from db_entities.aperture.aperture_glazing import ApertureElementGlazing
+from db_entities.aperture.frame_type import ApertureFrameType
+from db_entities.aperture.glazing_type import ApertureGlazingType
+from db_entities.app.project import Project
+from db_entities.app.user import User
+from features.auth.services import get_password_hash
+
+
+@pytest.fixture(scope="function")
+def test_db(session: Session) -> Generator[Session, None, None]:
+    """Alias for the session fixture to match test expectations."""
+    yield session
+
+
+@pytest.fixture(scope="function")
+def sample_aperture_with_elements(test_db: Session) -> Aperture:
+    """Create a sample aperture with elements, frames, and glazing for testing."""
+    # Create a test user
+    user = User(
+        username="test_aperture_user",
+        email="aperture_test@example.com",
+        hashed_password=get_password_hash("test123"),
+    )
+    test_db.add(user)
+    test_db.flush()
+
+    # Create a test project
+    project = Project(
+        name="Test Aperture Project",
+        bt_number="AP001",
+        owner_id=user.id,
+    )
+    test_db.add(project)
+    test_db.flush()
+
+    # Create frame type
+    frame_type = ApertureFrameType(
+        id="test_frame_type",
+        name="Test Frame Type",
+        width_mm=100.0,
+        u_value_w_m2k=1.0,
+        psi_g_w_mk=0.04,
+    )
+    test_db.add(frame_type)
+    test_db.flush()
+
+    # Create glazing type
+    glazing_type = ApertureGlazingType(
+        id="test_glazing_type",
+        name="Test Glazing Type",
+        u_value_w_m2k=1.0,
+        g_value=0.5,
+    )
+    test_db.add(glazing_type)
+    test_db.flush()
+
+    # Create aperture
+    aperture = Aperture(
+        name="Test Aperture",
+        project_id=project.id,
+        row_heights_mm=[1000.0],
+        column_widths_mm=[1000.0],
+    )
+    test_db.add(aperture)
+    test_db.flush()
+
+    # Create frames for the element
+    frame_top = ApertureElementFrame(
+        name="Top Frame",
+        frame_type_id=frame_type.id,
+    )
+    frame_right = ApertureElementFrame(
+        name="Right Frame",
+        frame_type_id=frame_type.id,
+    )
+    frame_bottom = ApertureElementFrame(
+        name="Bottom Frame",
+        frame_type_id=frame_type.id,
+    )
+    frame_left = ApertureElementFrame(
+        name="Left Frame",
+        frame_type_id=frame_type.id,
+    )
+    test_db.add_all([frame_top, frame_right, frame_bottom, frame_left])
+    test_db.flush()
+
+    # Create glazing
+    glazing = ApertureElementGlazing(
+        name="Test Glazing",
+        glazing_type_id=glazing_type.id,
+    )
+    test_db.add(glazing)
+    test_db.flush()
+
+    # Create aperture element
+    element = ApertureElement(
+        name="Test Element",
+        aperture_id=aperture.id,
+        row_number=1,
+        column_number=1,
+        row_span=1,
+        col_span=1,
+        frame_top_id=frame_top.id,
+        frame_right_id=frame_right.id,
+        frame_bottom_id=frame_bottom.id,
+        frame_left_id=frame_left.id,
+        glazing_id=glazing.id,
+    )
+    test_db.add(element)
+    test_db.commit()
+
+    # Refresh to load relationships
+    test_db.refresh(aperture)
+
+    return aperture

--- a/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/ApertureView/Aperture.EditButtons.tsx
+++ b/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/ApertureView/Aperture.EditButtons.tsx
@@ -15,7 +15,7 @@ const ApertureEditButton: React.FC<{ onClick: () => void; text: string; hoverTex
                     variant="outlined"
                     color="primary"
                     size="small"
-                    sx={{ marginBottom: 2, minWidth: '120px', color: 'inherit' }}
+                    sx={{ minWidth: '120px', color: 'inherit' }}
                     onClick={onClick}
                     disabled={disabled}
                 >
@@ -39,9 +39,8 @@ const ApertureEditButtons: React.FC = () => {
     return (
         <Box
             className="aperture-edit-buttons"
-            mb={2}
             display="flex"
-            justifyContent="right"
+            justifyContent="flex-start"
             alignItems="center"
             flexWrap="wrap"
             gap={1}

--- a/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/ApertureView/ApertureSelector.tsx
+++ b/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/ApertureView/ApertureSelector.tsx
@@ -1,0 +1,48 @@
+import { FormControl, Autocomplete, TextField } from '@mui/material';
+
+import { useApertures } from '../../../_contexts/Aperture.Context';
+import { ApertureType } from '../types';
+
+const ApertureSelector: React.FC = () => {
+    const { apertures, activeAperture, handleSetActiveApertureById } = useApertures();
+
+    // Sort apertures alphabetically by name
+    const sortedApertures = [...apertures].sort((a, b) => a.name.localeCompare(b.name));
+
+    return (
+        <FormControl sx={{ minWidth: 200, maxWidth: 300 }} size="small">
+            <Autocomplete
+                options={sortedApertures}
+                getOptionLabel={(option: ApertureType) => option.name}
+                value={activeAperture}
+                onChange={(_, newValue) => {
+                    if (newValue) {
+                        handleSetActiveApertureById(newValue.id);
+                    }
+                }}
+                isOptionEqualToValue={(option, value) => option.id === value?.id}
+                size="small"
+                renderInput={params => (
+                    <TextField
+                        {...params}
+                        placeholder="Select aperture..."
+                        variant="outlined"
+                        size="small"
+                        sx={{
+                            '& .MuiOutlinedInput-root': {
+                                fontSize: '0.875rem',
+                            },
+                        }}
+                    />
+                )}
+                renderOption={(props, option) => (
+                    <li {...props} key={option.id}>
+                        {option.name}
+                    </li>
+                )}
+            />
+        </FormControl>
+    );
+};
+
+export default ApertureSelector;

--- a/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/Page.tsx
+++ b/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/Page.tsx
@@ -1,24 +1,30 @@
 import { useContext } from 'react';
-import { Box, Grid } from '@mui/material';
+import { Box, IconButton } from '@mui/material';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 
 import { UserContext } from '../../../../../auth/_contexts/UserContext';
 import { useApertures } from '../../_contexts/Aperture.Context';
 import { ZoomProvider } from './ApertureView/Zoom.Context';
-import { ApertureSidebarProvider } from './Sidebar/Sidebar.Context';
+import { ApertureSidebarProvider, useApertureSidebar } from './Sidebar/Sidebar.Context';
 
 import ContentBlock from '../../../_components/ContentBlock';
 import ContentBlockHeader from '../../../_components/ContentBlock.Header';
 import LoadingModal from '../../../_components/LoadingModal';
 import ApertureTypesSidebar from './Sidebar/Sidebar';
 import ApertureEditButtons from './ApertureView/Aperture.EditButtons';
+import ApertureSelector from './ApertureView/ApertureSelector';
 import ApertureElements from './ApertureView/ElementsView/ApertureElements';
 import ApertureElementsTable from './ElementsTable/ElementsTable';
 import { useHeaderButtons } from './ApertureView/Aperture.HeaderButtons';
 
+const SIDEBAR_WIDTH = 260;
+
 const ApertureTypesContentBlock: React.FC = () => {
     const userContext = useContext(UserContext);
     const { activeAperture } = useApertures();
-    const headerButtons = useHeaderButtons(); // Always call the hook
+    const { isSidebarOpen, toggleSidebar } = useApertureSidebar();
+    const headerButtons = useHeaderButtons();
 
     return (
         <ContentBlock id="aperture-types">
@@ -26,21 +32,59 @@ const ApertureTypesContentBlock: React.FC = () => {
 
             <ContentBlockHeader text={`Window / Door Type [${activeAperture?.name}]`} buttons={headerButtons} />
 
-            <Grid container spacing={1} sx={{ margin: 2 }}>
-                {/* Sidebar Column */}
-                <Grid size={3}>
-                    <ApertureTypesSidebar />
-                </Grid>
+            <Box sx={{ display: 'flex', margin: 2 }}>
+                {/* Collapsible Sidebar - uses overflow:hidden to "cover" content when collapsing */}
+                <Box
+                    sx={{
+                        width: isSidebarOpen ? SIDEBAR_WIDTH : 0,
+                        minWidth: isSidebarOpen ? SIDEBAR_WIDTH : 0,
+                        overflow: 'hidden',
+                        transition: 'width 0.2s ease-in-out, min-width 0.2s ease-in-out',
+                        flexShrink: 0,
+                    }}
+                >
+                    <Box sx={{ width: SIDEBAR_WIDTH }}>
+                        <ApertureTypesSidebar />
+                    </Box>
+                </Box>
 
-                {/* Main Window Unit View */}
-                <Grid p={2} size={9} sx={{ borderLeft: '1px solid #ccc' }}>
+                {/* Toggle Button */}
+                <Box
+                    sx={{
+                        display: 'flex',
+                        alignItems: 'flex-start',
+                        pt: 1,
+                    }}
+                >
+                    <IconButton
+                        onClick={toggleSidebar}
+                        size="small"
+                        title={isSidebarOpen ? 'Collapse sidebar' : 'Expand sidebar'}
+                    >
+                        {isSidebarOpen ? <ChevronLeftIcon /> : <ChevronRightIcon />}
+                    </IconButton>
+                </Box>
+
+                {/* Main Content */}
+                <Box sx={{ flexGrow: 1, borderLeft: '1px solid #ccc', p: 2 }}>
                     <Box className="aperture-view">
-                        {userContext.user ? <ApertureEditButtons /> : null}
+                        {/* Toolbar row with dropdown and edit buttons aligned */}
+                        <Box
+                            display="flex"
+                            justifyContent="flex-start"
+                            alignItems="center"
+                            flexWrap="wrap"
+                            gap={1}
+                            mb={2}
+                        >
+                            <ApertureSelector />
+                            {userContext.user ? <ApertureEditButtons /> : null}
+                        </Box>
                         <ApertureElements />
                         <ApertureElementsTable />
                     </Box>
-                </Grid>
-            </Grid>
+                </Box>
+            </Box>
         </ContentBlock>
     );
 };

--- a/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/Sidebar/Sidebar.Context.tsx
+++ b/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/Sidebar/Sidebar.Context.tsx
@@ -12,6 +12,7 @@ export const ApertureSidebarProvider: React.FC<{ children: React.ReactNode }> = 
         apertureId: 0,
         apertureName: '',
     });
+    const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
     const { handleNameChange } = useApertures();
 
@@ -29,9 +30,22 @@ export const ApertureSidebarProvider: React.FC<{ children: React.ReactNode }> = 
         closeNameChangeModal();
     };
 
+    // Drawer toggle function
+    const toggleSidebar = () => {
+        setIsSidebarOpen(prev => !prev);
+    };
+
     return (
         <ApertureSidebarContext.Provider
-            value={{ nameChangeModal, setNameChangeModal, openNameChangeModal, closeNameChangeModal, handleNameSubmit }}
+            value={{
+                nameChangeModal,
+                setNameChangeModal,
+                openNameChangeModal,
+                closeNameChangeModal,
+                handleNameSubmit,
+                isSidebarOpen,
+                toggleSidebar,
+            }}
         >
             {children}
         </ApertureSidebarContext.Provider>

--- a/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/Sidebar/Sidebar.ListItemContent.tsx
+++ b/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/Sidebar/Sidebar.ListItemContent.tsx
@@ -1,6 +1,6 @@
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import { UserContext } from '../../../../../../auth/_contexts/UserContext';
-import { IconButton, ListItemButton, ListItemText, Stack, Tooltip } from '@mui/material';
+import { Box, IconButton, ListItemButton, ListItemText, Stack, Tooltip } from '@mui/material';
 import ModeEditOutlinedIcon from '@mui/icons-material/ModeEditOutlined';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import ClearOutlinedIcon from '@mui/icons-material/ClearOutlined';
@@ -15,21 +15,30 @@ import { ApertureListItemContentProps } from './types';
 const ApertureListItemContent: React.FC<ApertureListItemContentProps> = ({ aperture, isSelected }) => {
     const userContext = useContext(UserContext);
     const { handleSetActiveApertureById } = useApertures();
+    const [isHovered, setIsHovered] = useState(false);
 
     return (
         <ListItemButton
             selected={isSelected}
             onClick={() => handleSetActiveApertureById(aperture.id)}
+            onMouseEnter={() => setIsHovered(true)}
+            onMouseLeave={() => setIsHovered(false)}
             sx={listItemButtonSx}
         >
             <Stack direction="row" alignItems="center" width="100%">
                 <ListItemText primary={aperture.name} slotProps={listItemTextSlopProps} sx={listItemTextSx} />
                 {userContext.user && (
-                    <>
+                    <Box
+                        display="flex"
+                        sx={{
+                            opacity: isHovered ? 1 : 0,
+                            transition: 'opacity 0.15s ease-in-out',
+                        }}
+                    >
                         <EditNameButton aperture={aperture} />
                         <DuplicateButton aperture={aperture} />
                         <DeleteButton aperture={aperture} />
-                    </>
+                    </Box>
                 )}
             </Stack>
         </ListItemButton>
@@ -40,7 +49,7 @@ const EditNameButton: React.FC<{ aperture: ApertureType }> = ({ aperture }) => {
     const { openNameChangeModal } = useApertureSidebar();
 
     return (
-        <Tooltip className="edit-aperture-name-button" title="Aperture Name" placement="right" arrow>
+        <Tooltip className="edit-aperture-name-button" title="Edit Name" placement="bottom" arrow>
             <span>
                 <IconButton
                     size="small"
@@ -60,7 +69,7 @@ const DuplicateButton: React.FC<{ aperture: ApertureType }> = ({ aperture }) => 
     const { handleDuplicateAperture } = useApertures();
 
     return (
-        <Tooltip className="duplicate-aperture-button" title="Duplicate Aperture" placement="right" arrow>
+        <Tooltip className="duplicate-aperture-button" title="Duplicate Aperture" placement="bottom" arrow>
             <span>
                 <IconButton
                     size="small"
@@ -80,7 +89,7 @@ const DeleteButton: React.FC<{ aperture: ApertureType }> = ({ aperture }) => {
     const { handleDeleteAperture } = useApertures();
 
     return (
-        <Tooltip className="delete-aperture-button" title="Delete Aperture" placement="right" arrow>
+        <Tooltip className="delete-aperture-button" title="Delete Aperture" placement="bottom" arrow>
             <span>
                 <IconButton
                     size="small"

--- a/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/Sidebar/Sidebar.tsx
+++ b/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { List, ListItem } from '@mui/material';
+import { Box, List, ListItem } from '@mui/material';
 
 import { useApertures } from '../../../_contexts/Aperture.Context';
 
@@ -16,13 +16,24 @@ const ApertureTypesSidebar: React.FC = () => {
         <>
             <ChangeNameModal />
             <ApertureListHeader onAddAperture={handleAddAperture} />
-            <List dense>
-                {sortedApertures.map(aperture => (
-                    <ListItem key={aperture.id} component="div" disablePadding>
-                        <ApertureListItemContent aperture={aperture} isSelected={selectedApertureId === aperture.id} />
-                    </ListItem>
-                ))}
-            </List>
+            <Box
+                sx={{
+                    maxHeight: 'calc(100vh - 360px)',
+                    overflowY: 'auto',
+                    overflowX: 'hidden',
+                }}
+            >
+                <List dense>
+                    {sortedApertures.map(aperture => (
+                        <ListItem key={aperture.id} component="div" disablePadding>
+                            <ApertureListItemContent
+                                aperture={aperture}
+                                isSelected={selectedApertureId === aperture.id}
+                            />
+                        </ListItem>
+                    ))}
+                </List>
+            </Box>
         </>
     );
 };

--- a/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/Sidebar/__tests__/Sidebar.test.tsx
+++ b/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/Sidebar/__tests__/Sidebar.test.tsx
@@ -1,0 +1,272 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { UserContext } from '../../../../../../../auth/_contexts/UserContext';
+import ApertureTypesSidebar from '../Sidebar';
+import ApertureListItemContent from '../Sidebar.ListItemContent';
+import ApertureListHeader from '../Sidebar.ListHeader';
+import { ApertureSidebarProvider } from '../Sidebar.Context';
+import { mockApertures, mockUser, createMockAperturesContext, createMockSidebarContext } from './testUtils';
+
+// Mock the context modules
+jest.mock('../../../../_contexts/Aperture.Context', () => ({
+    useApertures: jest.fn(),
+}));
+
+jest.mock('../Sidebar.Context', () => ({
+    ...jest.requireActual('../Sidebar.Context'),
+    useApertureSidebar: jest.fn(),
+}));
+
+// Import the mocked modules
+import { useApertures } from '../../../../_contexts/Aperture.Context';
+import { useApertureSidebar } from '../Sidebar.Context';
+
+const mockUseApertures = useApertures as jest.MockedFunction<typeof useApertures>;
+const mockUseApertureSidebar = useApertureSidebar as jest.MockedFunction<typeof useApertureSidebar>;
+
+describe('ApertureTypesSidebar', () => {
+    beforeEach(() => {
+        mockUseApertures.mockReturnValue(createMockAperturesContext() as any);
+        mockUseApertureSidebar.mockReturnValue(createMockSidebarContext() as any);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('Rendering', () => {
+        it('renders the aperture list sorted alphabetically', () => {
+            render(
+                <UserContext.Provider value={{ user: mockUser, setUser: jest.fn() }}>
+                    <ApertureSidebarProvider>
+                        <ApertureTypesSidebar />
+                    </ApertureSidebarProvider>
+                </UserContext.Provider>
+            );
+
+            // Get all aperture names from the list
+            const doorC = screen.getByText('Door Type C');
+            const windowA = screen.getByText('Window Type A');
+            const windowB = screen.getByText('Window Type B');
+
+            // They should all be in the document
+            expect(doorC).toBeInTheDocument();
+            expect(windowA).toBeInTheDocument();
+            expect(windowB).toBeInTheDocument();
+
+            // Verify sorting by comparing their position in the DOM
+            // Door Type C should come before Window Type A (alphabetically)
+            const allTexts = screen.getAllByText(/Type/);
+            const textContents = allTexts.map(el => el.textContent);
+            expect(textContents).toEqual(['Door Type C', 'Window Type A', 'Window Type B']);
+        });
+
+        it('renders all apertures from the context', () => {
+            render(
+                <UserContext.Provider value={{ user: mockUser, setUser: jest.fn() }}>
+                    <ApertureSidebarProvider>
+                        <ApertureTypesSidebar />
+                    </ApertureSidebarProvider>
+                </UserContext.Provider>
+            );
+
+            expect(screen.getByText('Window Type A')).toBeInTheDocument();
+            expect(screen.getByText('Window Type B')).toBeInTheDocument();
+            expect(screen.getByText('Door Type C')).toBeInTheDocument();
+        });
+
+        it('renders empty list when no apertures exist', () => {
+            mockUseApertures.mockReturnValue(
+                createMockAperturesContext({
+                    apertures: [],
+                    selectedApertureId: null,
+                    activeAperture: null,
+                }) as any
+            );
+
+            render(
+                <UserContext.Provider value={{ user: mockUser, setUser: jest.fn() }}>
+                    <ApertureSidebarProvider>
+                        <ApertureTypesSidebar />
+                    </ApertureSidebarProvider>
+                </UserContext.Provider>
+            );
+
+            // Only the Add button should be visible
+            const listItems = screen.queryAllByRole('listitem');
+            expect(listItems).toHaveLength(0);
+        });
+    });
+});
+
+describe('ApertureListHeader', () => {
+    it('renders Add New Aperture button for logged-in users', () => {
+        const onAddAperture = jest.fn();
+
+        render(
+            <UserContext.Provider value={{ user: mockUser, setUser: jest.fn() }}>
+                <ApertureListHeader onAddAperture={onAddAperture} />
+            </UserContext.Provider>
+        );
+
+        expect(screen.getByText('+ Add New Aperture')).toBeInTheDocument();
+    });
+
+    it('does not render Add New Aperture button for logged-out users', () => {
+        const onAddAperture = jest.fn();
+
+        render(
+            <UserContext.Provider value={{ user: null, setUser: jest.fn() }}>
+                <ApertureListHeader onAddAperture={onAddAperture} />
+            </UserContext.Provider>
+        );
+
+        expect(screen.queryByText('+ Add New Aperture')).not.toBeInTheDocument();
+    });
+
+    it('calls onAddAperture when button is clicked', () => {
+        const onAddAperture = jest.fn();
+
+        render(
+            <UserContext.Provider value={{ user: mockUser, setUser: jest.fn() }}>
+                <ApertureListHeader onAddAperture={onAddAperture} />
+            </UserContext.Provider>
+        );
+
+        fireEvent.click(screen.getByText('+ Add New Aperture'));
+        expect(onAddAperture).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('ApertureListItemContent', () => {
+    beforeEach(() => {
+        mockUseApertures.mockReturnValue(createMockAperturesContext() as any);
+        mockUseApertureSidebar.mockReturnValue(createMockSidebarContext() as any);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const aperture = mockApertures[0];
+
+    describe('Selection', () => {
+        it('highlights selected item', () => {
+            render(
+                <UserContext.Provider value={{ user: mockUser, setUser: jest.fn() }}>
+                    <ApertureListItemContent aperture={aperture} isSelected={true} />
+                </UserContext.Provider>
+            );
+
+            // Find the main list item button (the one containing the aperture name)
+            const listItemButton = screen.getByText(aperture.name).closest('[role="button"]');
+            expect(listItemButton).toHaveClass('Mui-selected');
+        });
+
+        it('does not highlight non-selected item', () => {
+            render(
+                <UserContext.Provider value={{ user: mockUser, setUser: jest.fn() }}>
+                    <ApertureListItemContent aperture={aperture} isSelected={false} />
+                </UserContext.Provider>
+            );
+
+            const listItemButton = screen.getByText(aperture.name).closest('[role="button"]');
+            expect(listItemButton).not.toHaveClass('Mui-selected');
+        });
+
+        it('calls handleSetActiveApertureById when item is clicked', () => {
+            const mockContext = createMockAperturesContext();
+            mockUseApertures.mockReturnValue(mockContext as any);
+
+            render(
+                <UserContext.Provider value={{ user: mockUser, setUser: jest.fn() }}>
+                    <ApertureListItemContent aperture={aperture} isSelected={false} />
+                </UserContext.Provider>
+            );
+
+            const listItemButton = screen.getByText(aperture.name).closest('[role="button"]');
+            fireEvent.click(listItemButton!);
+            expect(mockContext.handleSetActiveApertureById).toHaveBeenCalledWith(aperture.id);
+        });
+    });
+
+    describe('Action Buttons', () => {
+        it('renders edit, duplicate, and delete buttons for logged-in users', () => {
+            render(
+                <UserContext.Provider value={{ user: mockUser, setUser: jest.fn() }}>
+                    <ApertureListItemContent aperture={aperture} isSelected={false} />
+                </UserContext.Provider>
+            );
+
+            // Check for icon buttons (edit, duplicate, delete)
+            const iconButtons = screen.getAllByRole('button');
+            // Main button + 3 action buttons
+            expect(iconButtons.length).toBeGreaterThanOrEqual(3);
+        });
+
+        it('does not render action buttons for logged-out users', () => {
+            render(
+                <UserContext.Provider value={{ user: null, setUser: jest.fn() }}>
+                    <ApertureListItemContent aperture={aperture} isSelected={false} />
+                </UserContext.Provider>
+            );
+
+            // Only the main list item button should exist
+            const buttons = screen.getAllByRole('button');
+            expect(buttons).toHaveLength(1);
+        });
+
+        it('calls openNameChangeModal when edit button is clicked', () => {
+            const mockSidebarContext = createMockSidebarContext();
+            mockUseApertureSidebar.mockReturnValue(mockSidebarContext as any);
+
+            render(
+                <UserContext.Provider value={{ user: mockUser, setUser: jest.fn() }}>
+                    <ApertureListItemContent aperture={aperture} isSelected={false} />
+                </UserContext.Provider>
+            );
+
+            // Find the edit button (first icon button after the main button)
+            const editButton = document.querySelector('.edit-aperture-name-button button');
+            expect(editButton).toBeInTheDocument();
+
+            fireEvent.click(editButton!);
+            expect(mockSidebarContext.openNameChangeModal).toHaveBeenCalledWith(aperture.id, aperture.name);
+        });
+
+        it('calls handleDuplicateAperture when duplicate button is clicked', () => {
+            const mockContext = createMockAperturesContext();
+            mockUseApertures.mockReturnValue(mockContext as any);
+
+            render(
+                <UserContext.Provider value={{ user: mockUser, setUser: jest.fn() }}>
+                    <ApertureListItemContent aperture={aperture} isSelected={false} />
+                </UserContext.Provider>
+            );
+
+            const duplicateButton = document.querySelector('.duplicate-aperture-button button');
+            expect(duplicateButton).toBeInTheDocument();
+
+            fireEvent.click(duplicateButton!);
+            expect(mockContext.handleDuplicateAperture).toHaveBeenCalledWith(aperture.id);
+        });
+
+        it('calls handleDeleteAperture when delete button is clicked', () => {
+            const mockContext = createMockAperturesContext();
+            mockUseApertures.mockReturnValue(mockContext as any);
+
+            render(
+                <UserContext.Provider value={{ user: mockUser, setUser: jest.fn() }}>
+                    <ApertureListItemContent aperture={aperture} isSelected={false} />
+                </UserContext.Provider>
+            );
+
+            const deleteButton = document.querySelector('.delete-aperture-button button');
+            expect(deleteButton).toBeInTheDocument();
+
+            fireEvent.click(deleteButton!);
+            expect(mockContext.handleDeleteAperture).toHaveBeenCalledWith(aperture.id);
+        });
+    });
+});

--- a/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/Sidebar/__tests__/testUtils.tsx
+++ b/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/Sidebar/__tests__/testUtils.tsx
@@ -1,0 +1,88 @@
+import { ApertureType } from '../../types';
+
+// Mock aperture data for testing
+export const mockApertures: ApertureType[] = [
+    {
+        id: 1,
+        name: 'Window Type A',
+        column_widths_mm: [500],
+        row_heights_mm: [1000],
+        elements: [],
+    },
+    {
+        id: 2,
+        name: 'Window Type B',
+        column_widths_mm: [600],
+        row_heights_mm: [1200],
+        elements: [],
+    },
+    {
+        id: 3,
+        name: 'Door Type C',
+        column_widths_mm: [900],
+        row_heights_mm: [2100],
+        elements: [],
+    },
+];
+
+// Mock user for authenticated state
+export const mockUser = {
+    id: '1',
+    email: 'test@example.com',
+    name: 'Test User',
+};
+
+// Factory function for creating mock AperturesContext values
+export const createMockAperturesContext = (overrides = {}) => ({
+    isLoadingApertures: false,
+    setIsLoadingApertures: jest.fn(),
+    apertures: mockApertures,
+    setApertures: jest.fn(),
+    selectedApertureId: 1,
+    activeAperture: mockApertures[0],
+    setSelectedApertureId: jest.fn(),
+    handleSetActiveApertureById: jest.fn(),
+    handleSetActiveAperture: jest.fn(),
+    handleNameChange: jest.fn(),
+    handleAddAperture: jest.fn(),
+    handleDeleteAperture: jest.fn(),
+    handleDuplicateAperture: jest.fn(),
+    handleUpdateAperture: jest.fn(),
+    handleAddRow: jest.fn(),
+    handleDeleteRow: jest.fn(),
+    handleAddColumn: jest.fn(),
+    handleDeleteColumn: jest.fn(),
+    getCellSize: jest.fn(() => ({ width: 100, height: 100 })),
+    updateColumnWidth: jest.fn(),
+    updateRowHeight: jest.fn(),
+    selectedApertureElementIds: [],
+    toggleApertureElementSelection: jest.fn(),
+    clearApertureElementIdSelection: jest.fn(),
+    mergeSelectedApertureElements: jest.fn(),
+    splitSelectedApertureElement: jest.fn(),
+    handleUpdateApertureElementFrameType: jest.fn(),
+    updateApertureElementName: jest.fn(),
+    handleUpdateApertureElementGlazing: jest.fn(),
+    ...overrides,
+});
+
+// Factory function for creating mock ApertureSidebarContext values
+export const createMockSidebarContext = (overrides = {}) => ({
+    nameChangeModal: {
+        isOpen: false,
+        apertureId: 0,
+        apertureName: '',
+    },
+    setNameChangeModal: jest.fn(),
+    openNameChangeModal: jest.fn(),
+    closeNameChangeModal: jest.fn(),
+    handleNameSubmit: jest.fn(),
+    isSidebarOpen: true,
+    toggleSidebar: jest.fn(),
+    ...overrides,
+});
+
+// Dummy test to prevent "Your test suite must contain at least one test" error
+test('testUtils module loads correctly', () => {
+    expect(mockApertures).toHaveLength(3);
+});

--- a/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/Sidebar/types.ts
+++ b/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/Sidebar/types.ts
@@ -13,9 +13,11 @@ export interface ApertureSidebarContextType {
             apertureName: string;
         }>
     >;
-    openNameChangeModal: (id: any, name: string) => void;
+    openNameChangeModal: (id: number, name: string) => void;
     closeNameChangeModal: () => void;
     handleNameSubmit: (newName: string) => void;
+    isSidebarOpen: boolean;
+    toggleSidebar: () => void;
 }
 
 export interface ApertureListItemContentProps {


### PR DESCRIPTION
Introduces an ApertureSelector dropdown for switching apertures and implements a collapsible sidebar for the UnitBuilder page. Sidebar list items now show action buttons (edit, duplicate, delete) only on hover, and the sidebar content is scrollable. Adds comprehensive tests for sidebar components and updates context and types to support sidebar open/close state. Also includes backend test fixtures for aperture-related tests and minor UI/UX improvements.