### PR TITLE
UI/windows toolbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ backend/alembic/db_backups/*
 
 # Claude
 .claude/
+CLAUDE.md
 
 # dependencies
 frontend/node_modules

--- a/frontend/src/features/project_view/data_views/_components/ContentBlock.Header.tsx
+++ b/frontend/src/features/project_view/data_views/_components/ContentBlock.Header.tsx
@@ -4,9 +4,11 @@ import { contentBlockHeaderStyle } from '../_styles/ContentBlock.Header.Style';
 type ContentBlockHeaderProps = {
     text: string;
     buttons?: React.ReactNode[];
+    titleContent?: React.ReactNode;
+    id?: string;
 };
 
-const ContentBlockHeader: React.FC<ContentBlockHeaderProps> = ({ text, buttons = [] }) => {
+const ContentBlockHeader: React.FC<ContentBlockHeaderProps> = ({ text, buttons = [], titleContent, id }) => {
     return (
         <Stack
             className="content-block-heading"
@@ -15,9 +17,10 @@ const ContentBlockHeader: React.FC<ContentBlockHeaderProps> = ({ text, buttons =
             justifyContent="space-between"
             spacing={1}
             sx={contentBlockHeaderStyle}
+            id={id}
         >
             {/* Header Text */}
-            <h4 style={{ margin: 0 }}>{text}</h4>
+            {titleContent ?? <h4 style={{ margin: 0 }}>{text}</h4>}
 
             {/* Header Buttons */}
             <Box sx={{ display: 'flex', gap: '8px' }}>

--- a/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/ApertureView/Aperture.HeaderButtons.tsx
+++ b/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/ApertureView/Aperture.HeaderButtons.tsx
@@ -1,97 +1,102 @@
-import { Button, Tooltip } from '@mui/material';
+import { CircularProgress, IconButton, ListItemIcon, ListItemText, Menu, MenuItem, Tooltip } from '@mui/material';
 import RefreshRoundedIcon from '@mui/icons-material/RefreshRounded';
-import ZoomInIcon from '@mui/icons-material/ZoomIn';
-import ZoomOutIcon from '@mui/icons-material/ZoomOut';
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import { useFrameTypes } from '../../../_contexts/FrameType.Context';
 import { useGlazingTypes } from '../../../_contexts/GlazingTypes.Context';
-import { useZoom } from './Zoom.Context';
-import { useContext } from 'react';
+import { useContext, useMemo, useState } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { UserContext } from '../../../../../../auth/_contexts/UserContext';
 
-type HeaderButtonId = 'refresh_frames' | 'refresh_glazings' | 'zoom_in' | 'zoom_out';
-
-interface HeaderButtonProps {
-    id: HeaderButtonId;
-    text: string;
-    icon?: React.ReactNode | null;
+interface HeaderActionItem {
+    id: 'refresh_frames' | 'refresh_glazings';
+    label: string;
+    helperText: string;
+    icon: ReactNode;
     handler: () => void | Promise<void>;
     loading?: boolean;
-    disabled?: boolean;
 }
 
-const hoverText = {
-    refresh_frames: 'Reload the frame-types from the AirTable database.',
-    refresh_glazings: 'Reload the glazing-types from the AirTable database.',
-    zoom_in: 'Zoom in to see more detail.',
-    zoom_out: 'Zoom out to see more of the aperture.',
-};
+const HeaderActionsMenu: React.FC<{ items: HeaderActionItem[] }> = ({ items }) => {
+    const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+    const isOpen = Boolean(anchorEl);
 
-const HeaderTextIconButton: React.FC<HeaderButtonProps> = ({ id, text, icon, handler, loading, disabled }) => {
+    const handleOpen = (event: React.MouseEvent<HTMLElement>) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handleClose = () => {
+        setAnchorEl(null);
+    };
+
     return (
-        <Tooltip title={hoverText[id]} placement="top" arrow>
-            <span>
-                <Button
-                    className="header-button"
-                    variant="outlined"
-                    color="inherit"
+        <>
+            <Tooltip title="More actions" placement="top" arrow>
+                <IconButton
                     size="small"
-                    onClick={handler}
-                    disabled={loading || disabled}
-                    startIcon={icon}
+                    onClick={handleOpen}
+                    aria-label="More actions"
+                    aria-controls={isOpen ? 'aperture-header-actions-menu' : undefined}
+                    aria-haspopup="true"
+                    aria-expanded={isOpen ? 'true' : undefined}
                 >
-                    {loading ? 'Loading....' : text}
-                </Button>
-            </span>
-        </Tooltip>
+                    <MoreHorizIcon />
+                </IconButton>
+            </Tooltip>
+
+            <Menu
+                id="aperture-header-actions-menu"
+                anchorEl={anchorEl}
+                open={isOpen}
+                onClose={handleClose}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+            >
+                {items.map(item => (
+                    <MenuItem
+                        key={item.id}
+                        disabled={item.loading}
+                        onClick={() => {
+                            handleClose();
+                            item.handler();
+                        }}
+                    >
+                        <ListItemIcon sx={{ minWidth: 28 }}>
+                            {item.loading ? <CircularProgress size={16} /> : item.icon}
+                        </ListItemIcon>
+                        <ListItemText primary={item.label} secondary={item.helperText} />
+                    </MenuItem>
+                ))}
+            </Menu>
+        </>
     );
 };
 
-export function useHeaderButtons(): React.ReactElement[] {
+export function useHeaderButtons(): ReactElement[] {
     const userContext = useContext(UserContext);
     const { isLoadingFrameTypes, handleRefreshFrameTypes } = useFrameTypes();
     const { isLoadingGlazingTypes, handleRefreshGlazingTypes } = useGlazingTypes();
-    const { zoomIn, zoomOut, scaleFactor, getScaleLabel } = useZoom();
 
-    // Calculate if zoom buttons should be disabled based on scale limits
-    const isZoomInDisabled = scaleFactor >= 1.0;
-    const isZoomOutDisabled = scaleFactor <= 0.05;
+    const menuItems = useMemo<HeaderActionItem[]>(
+        () => [
+            {
+                id: 'refresh_frames',
+                label: 'Refresh frame types',
+                helperText: 'Reload from AirTable',
+                icon: <RefreshRoundedIcon fontSize="small" />,
+                handler: handleRefreshFrameTypes,
+                loading: isLoadingFrameTypes,
+            },
+            {
+                id: 'refresh_glazings',
+                label: 'Refresh glazing types',
+                helperText: 'Reload from AirTable',
+                icon: <RefreshRoundedIcon fontSize="small" />,
+                handler: handleRefreshGlazingTypes,
+                loading: isLoadingGlazingTypes,
+            },
+        ],
+        [handleRefreshFrameTypes, handleRefreshGlazingTypes, isLoadingFrameTypes, isLoadingGlazingTypes]
+    );
 
-    const scale_buttons = [
-        <HeaderTextIconButton
-            key={'zoom_out'}
-            id={'zoom_out'}
-            text={`Zoom Out`}
-            icon={<ZoomOutIcon />}
-            handler={zoomOut}
-            disabled={isZoomOutDisabled}
-        />,
-        <HeaderTextIconButton
-            key={'zoom_in'}
-            id={'zoom_in'}
-            text={`Zoom In (${getScaleLabel()})`}
-            icon={<ZoomInIcon />}
-            handler={zoomIn}
-            disabled={isZoomInDisabled}
-        />,
-    ];
-    const refreshButtons = [
-        <HeaderTextIconButton
-            key={'refresh_frames'}
-            id={'refresh_frames'}
-            text={'Refresh Frame-Types From AirTable'}
-            icon={<RefreshRoundedIcon />}
-            handler={handleRefreshFrameTypes}
-            loading={isLoadingFrameTypes}
-        />,
-        <HeaderTextIconButton
-            key={'refresh_glazings'}
-            id={'refresh_glazings'}
-            text={'Refresh Glazing-Types From AirTable'}
-            icon={<RefreshRoundedIcon />}
-            handler={handleRefreshGlazingTypes}
-            loading={isLoadingGlazingTypes}
-        />,
-    ];
-
-    return userContext.user ? [...refreshButtons, ...scale_buttons] : [...scale_buttons];
+    return userContext.user ? [<HeaderActionsMenu key="header-actions" items={menuItems} />] : [];
 }

--- a/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/ApertureView/ApertureSelector.tsx
+++ b/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/ApertureView/ApertureSelector.tsx
@@ -10,7 +10,27 @@ const ApertureSelector: React.FC = () => {
     const sortedApertures = [...apertures].sort((a, b) => a.name.localeCompare(b.name));
 
     return (
-        <FormControl sx={{ minWidth: 200, maxWidth: 300 }} size="small">
+        <FormControl
+            sx={{
+                minWidth: 330,
+                maxWidth: 480,
+                '& .MuiOutlinedInput-root': {
+                    backgroundColor: '#fff',
+                    borderRadius: '8px',
+                },
+                '& .MuiOutlinedInput-notchedOutline': {
+                    borderColor: 'var(--outline-color)',
+                },
+                '&:hover .MuiOutlinedInput-notchedOutline': {
+                    borderColor: 'var(--text-secondary-color)',
+                },
+                '& .MuiAutocomplete-inputRoot': {
+                    paddingTop: '4px',
+                    paddingBottom: '4px',
+                },
+            }}
+            size="small"
+        >
             <Autocomplete
                 options={sortedApertures}
                 getOptionLabel={(option: ApertureType) => option.name}

--- a/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/ApertureView/ApertureToolbar.tsx
+++ b/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/ApertureView/ApertureToolbar.tsx
@@ -1,0 +1,171 @@
+import { useContext } from 'react';
+import type { FC, ReactNode } from 'react';
+import { Box, IconButton, Tooltip } from '@mui/material';
+import ZoomInIcon from '@mui/icons-material/ZoomIn';
+import ZoomOutIcon from '@mui/icons-material/ZoomOut';
+import CallMergeIcon from '@mui/icons-material/CallMerge';
+import CallSplitIcon from '@mui/icons-material/CallSplit';
+import ClearIcon from '@mui/icons-material/Clear';
+import ViewColumnOutlinedIcon from '@mui/icons-material/ViewColumnOutlined';
+import TableRowsOutlinedIcon from '@mui/icons-material/TableRowsOutlined';
+
+import { useZoom } from './Zoom.Context';
+import { useApertures } from '../../../_contexts/Aperture.Context';
+import { UserContext } from '../../../../../../auth/_contexts/UserContext';
+
+interface ToolbarIconButtonProps {
+    icon: ReactNode;
+    onClick: () => void;
+    disabled?: boolean;
+    tooltipText: string;
+}
+
+const ToolbarIconButton: FC<ToolbarIconButtonProps> = ({ icon, onClick, disabled = false, tooltipText }) => {
+    return (
+        <Tooltip title={tooltipText} placement="top" arrow enterDelay={300}>
+            <span>
+                <IconButton
+                    onClick={onClick}
+                    disabled={disabled}
+                    size="small"
+                    sx={{
+                        width: 24,
+                        height: 24,
+                        borderRadius: '4px',
+                        transition: 'transform 150ms ease-out, background-color 150ms ease-out',
+                        '&:hover': disabled
+                            ? undefined
+                            : {
+                                  backgroundColor: 'var(--highlight-light-color)',
+                                  transform: 'scale(1.05)',
+                              },
+                        '&:active': disabled
+                            ? undefined
+                            : {
+                                  transform: 'scale(0.95)',
+                              },
+                        '&.Mui-disabled': {
+                            opacity: 0.4,
+                            cursor: 'not-allowed',
+                        },
+                    }}
+                    aria-label={tooltipText}
+                >
+                    {icon}
+                </IconButton>
+            </span>
+        </Tooltip>
+    );
+};
+
+const ToolbarDivider: FC = () => {
+    return (
+        <Box
+            sx={{
+                width: '1px',
+                height: '14px',
+                backgroundColor: 'var(--outline-color)',
+                mx: 0.75,
+            }}
+        />
+    );
+};
+
+const ApertureToolbar: FC = () => {
+    const userContext = useContext(UserContext);
+    const { zoomIn, zoomOut, scaleFactor } = useZoom();
+    const {
+        activeAperture,
+        selectedApertureElementIds,
+        mergeSelectedApertureElements,
+        splitSelectedApertureElement,
+        clearApertureElementIdSelection,
+        handleAddRow,
+        handleAddColumn,
+    } = useApertures();
+
+    const isZoomInDisabled = scaleFactor >= 1.0;
+    const isZoomOutDisabled = scaleFactor <= 0.05;
+    const isMergeDisabled = selectedApertureElementIds.length < 2;
+    const isSplitDisabled = selectedApertureElementIds.length !== 1;
+    const isClearDisabled = selectedApertureElementIds.length === 0;
+    const isGridDisabled = !activeAperture;
+
+    const mergeTooltip = isMergeDisabled
+        ? 'Select 2+ elements to merge'
+        : `Merge selected (${selectedApertureElementIds.length} elements)`;
+    const splitTooltip = isSplitDisabled ? 'Select 1 element to split' : 'Split selected element';
+    const clearTooltip = isClearDisabled ? 'Select elements to clear' : 'Clear selection';
+
+    return (
+        <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+            <Box
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 0.25,
+                    px: 0.75,
+                    py: '2px',
+                    backgroundColor: 'var(--appbar-bg-color)',
+                    border: '1px solid var(--outline-color)',
+                    borderRadius: '6px',
+                    boxShadow: '0 1px 4px rgba(0,0,0,0.06)',
+                    maxWidth: '100%',
+                    flexWrap: 'wrap',
+                }}
+            >
+                <ToolbarIconButton
+                    icon={<ZoomInIcon fontSize="small" />}
+                    onClick={zoomIn}
+                    disabled={isZoomInDisabled}
+                    tooltipText="Zoom in"
+                />
+                <ToolbarIconButton
+                    icon={<ZoomOutIcon fontSize="small" />}
+                    onClick={zoomOut}
+                    disabled={isZoomOutDisabled}
+                    tooltipText="Zoom out"
+                />
+
+                {userContext.user && (
+                    <>
+                        <ToolbarDivider />
+                        <ToolbarIconButton
+                            icon={<CallMergeIcon fontSize="small" />}
+                            onClick={mergeSelectedApertureElements}
+                            disabled={isMergeDisabled}
+                            tooltipText={mergeTooltip}
+                        />
+                        <ToolbarIconButton
+                            icon={<CallSplitIcon fontSize="small" />}
+                            onClick={splitSelectedApertureElement}
+                            disabled={isSplitDisabled}
+                            tooltipText={splitTooltip}
+                        />
+                        <ToolbarIconButton
+                            icon={<ClearIcon fontSize="small" />}
+                            onClick={clearApertureElementIdSelection}
+                            disabled={isClearDisabled}
+                            tooltipText={clearTooltip}
+                        />
+                        <ToolbarDivider />
+                        <ToolbarIconButton
+                            icon={<ViewColumnOutlinedIcon fontSize="small" />}
+                            onClick={handleAddColumn}
+                            disabled={isGridDisabled}
+                            tooltipText="Add column"
+                        />
+                        <ToolbarIconButton
+                            icon={<TableRowsOutlinedIcon fontSize="small" />}
+                            onClick={handleAddRow}
+                            disabled={isGridDisabled}
+                            tooltipText="Add row"
+                        />
+                    </>
+                )}
+            </Box>
+        </Box>
+    );
+};
+
+export default ApertureToolbar;

--- a/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/ApertureView/ElementsView/ApertureElements.tsx
+++ b/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/ApertureView/ElementsView/ApertureElements.tsx
@@ -1,8 +1,9 @@
-import { Box, Stack, Typography } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 
 import { useApertures } from '../../../../_contexts/Aperture.Context';
 import { useZoom } from '../Zoom.Context';
 import { DimensionsProvider } from '../../Dimensions/Dimensions.Context';
+import ApertureToolbar from '../ApertureToolbar';
 
 import ApertureElementContainer from './ApertureElement.Container';
 import ElementLabelsOverlay from './ElementLabelsOverlay';
@@ -54,7 +55,7 @@ const ApertureElementsDisplay: React.FC = () => {
 
 const ApertureElements: React.FC = () => {
     const { activeAperture, updateColumnWidth, updateRowHeight } = useApertures();
-    const { scaleFactor, getScaleLabel } = useZoom();
+    const { scaleFactor } = useZoom();
 
     if (!activeAperture) {
         return <Box sx={{ p: 2 }}>No aperture selected</Box>;
@@ -69,22 +70,18 @@ const ApertureElements: React.FC = () => {
     return (
         <Stack
             className="aperture-elements-container"
-            spacing={2}
+            spacing={4}
             sx={{
                 position: 'relative',
                 pl: 12,
                 pb: 8,
-                pt: 1,
+                pt: 0.0,
                 pr: 1,
-                mt: 4,
+                mt: 0.0,
                 overflow: 'hidden', // Clip Aperture SVG content that exceeds bounds
             }}
         >
-            {/* Scale indicator */}
-            <Typography variant="caption" sx={{ alignSelf: 'flex-end', color: 'text.secondary' }}>
-                Scale: {getScaleLabel()} | {totalWidthMM}mm x {totalHeightMM}mm
-            </Typography>
-
+            <ApertureToolbar />
             <Box
                 className="aperture-elements-display-container"
                 sx={{

--- a/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/Page.tsx
+++ b/frontend/src/features/project_view/data_views/windows/pages/UnitBuilder/Page.tsx
@@ -1,9 +1,7 @@
-import { useContext } from 'react';
 import { Box, IconButton } from '@mui/material';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 
-import { UserContext } from '../../../../../auth/_contexts/UserContext';
 import { useApertures } from '../../_contexts/Aperture.Context';
 import { ZoomProvider } from './ApertureView/Zoom.Context';
 import { ApertureSidebarProvider, useApertureSidebar } from './Sidebar/Sidebar.Context';
@@ -12,7 +10,6 @@ import ContentBlock from '../../../_components/ContentBlock';
 import ContentBlockHeader from '../../../_components/ContentBlock.Header';
 import LoadingModal from '../../../_components/LoadingModal';
 import ApertureTypesSidebar from './Sidebar/Sidebar';
-import ApertureEditButtons from './ApertureView/Aperture.EditButtons';
 import ApertureSelector from './ApertureView/ApertureSelector';
 import ApertureElements from './ApertureView/ElementsView/ApertureElements';
 import ApertureElementsTable from './ElementsTable/ElementsTable';
@@ -21,7 +18,6 @@ import { useHeaderButtons } from './ApertureView/Aperture.HeaderButtons';
 const SIDEBAR_WIDTH = 260;
 
 const ApertureTypesContentBlock: React.FC = () => {
-    const userContext = useContext(UserContext);
     const { activeAperture } = useApertures();
     const { isSidebarOpen, toggleSidebar } = useApertureSidebar();
     const headerButtons = useHeaderButtons();
@@ -30,11 +26,22 @@ const ApertureTypesContentBlock: React.FC = () => {
         <ContentBlock id="aperture-types">
             <LoadingModal showModal={false} />
 
-            <ContentBlockHeader text={`Window / Door Type [${activeAperture?.name}]`} buttons={headerButtons} />
+            <ContentBlockHeader
+                id="aperture-types-header"
+                text={`Window / Door Type`}
+                buttons={headerButtons}
+                titleContent={
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <h4 style={{ margin: 0 }}>Window / Door Type</h4>
+                        <ApertureSelector />
+                    </Box>
+                }
+            />
 
-            <Box sx={{ display: 'flex', margin: 2 }}>
+            <Box id="aperture-types-active-view-container" sx={{ display: 'flex', margin: 2 }}>
                 {/* Collapsible Sidebar - uses overflow:hidden to "cover" content when collapsing */}
                 <Box
+                    id="aperture-types-sidebar"
                     sx={{
                         width: isSidebarOpen ? SIDEBAR_WIDTH : 0,
                         minWidth: isSidebarOpen ? SIDEBAR_WIDTH : 0,
@@ -50,6 +57,7 @@ const ApertureTypesContentBlock: React.FC = () => {
 
                 {/* Toggle Button */}
                 <Box
+                    id="aperture-types-sidebar-toggle"
                     sx={{
                         display: 'flex',
                         alignItems: 'flex-start',
@@ -57,6 +65,7 @@ const ApertureTypesContentBlock: React.FC = () => {
                     }}
                 >
                     <IconButton
+                        id="aperture-types-sidebar-toggle-button"
                         onClick={toggleSidebar}
                         size="small"
                         title={isSidebarOpen ? 'Collapse sidebar' : 'Expand sidebar'}
@@ -66,20 +75,8 @@ const ApertureTypesContentBlock: React.FC = () => {
                 </Box>
 
                 {/* Main Content */}
-                <Box sx={{ flexGrow: 1, borderLeft: '1px solid #ccc', p: 2 }}>
+                <Box id="aperture-types-content" sx={{ flexGrow: 1, borderLeft: '1px solid #ccc', p: 2, pt: 0 }}>
                     <Box className="aperture-view">
-                        {/* Toolbar row with dropdown and edit buttons aligned */}
-                        <Box
-                            display="flex"
-                            justifyContent="flex-start"
-                            alignItems="center"
-                            flexWrap="wrap"
-                            gap={1}
-                            mb={2}
-                        >
-                            <ApertureSelector />
-                            {userContext.user ? <ApertureEditButtons /> : null}
-                        </Box>
                         <ApertureElements />
                         <ApertureElementsTable />
                     </Box>


### PR DESCRIPTION
This pull request refactors and enhances the user interface for the Aperture (Window/Door Type) editor in the UnitBuilder feature. The main improvements include introducing a new toolbar for aperture element actions, redesigning the header area to include a more flexible layout and dropdown menu, and updating the styling for better usability and clarity. The zoom and element manipulation controls have been separated into a dedicated toolbar, and the header action buttons have been consolidated into a menu.

**UI/UX Improvements**

* Added a new `ApertureToolbar` component that provides zoom, merge, split, clear, and grid manipulation actions in a compact, visually distinct toolbar above the aperture elements area. This moves zoom and element actions out of the header and into a dedicated location for better discoverability and usability. [[1]](diffhunk://#diff-5f9b454ba0d8674d2efbaa71c55c649ade6467c1085417f686e80e2e28dc2ed6R1-R171) [[2]](diffhunk://#diff-c97b900f419773c58e4f6d3f908ec7f3e2f1982008d35be958124ae2615db55eL1-R6) [[3]](diffhunk://#diff-c97b900f419773c58e4f6d3f908ec7f3e2f1982008d35be958124ae2615db55eL57-R58) [[4]](diffhunk://#diff-c97b900f419773c58e4f6d3f908ec7f3e2f1982008d35be958124ae2615db55eL72-R84)
* Redesigned the `ContentBlockHeader` component to allow for custom `titleContent` (such as a combined header and `ApertureSelector`), and added support for an optional `id` prop for better accessibility and testing. [[1]](diffhunk://#diff-40e4a69b6405a1edf1cb09d6b271a76bd8da3200e5fe6dda1d3cde131e544095R7-R11) [[2]](diffhunk://#diff-40e4a69b6405a1edf1cb09d6b271a76bd8da3200e5fe6dda1d3cde131e544095R20-R23) [[3]](diffhunk://#diff-e26b2fda065f8eed3db15c63f82800fa96450756674e93c514ae159aea6b3ab9L33-R44)

**Header Actions Refactor**

* Replaced individual refresh and zoom buttons in the header with a single "More actions" dropdown menu (`HeaderActionsMenu`), streamlining the available actions and decluttering the header area. Zoom controls are now in the new toolbar.

**Styling and Layout Updates**

* Enhanced the `ApertureSelector` styling for better appearance and consistency, increasing its size and improving input field appearance on hover and focus.
* Adjusted spacing and padding in the aperture elements container for a cleaner layout, and removed the old scale indicator from the UI.

**Code Cleanup**

* Removed unused imports and legacy components related to header buttons and zoom from the relevant files, as their functionality is now handled by the new toolbar and menu. [[1]](diffhunk://#diff-e26b2fda065f8eed3db15c63f82800fa96450756674e93c514ae159aea6b3ab9L1-L6) [[2]](diffhunk://#diff-e26b2fda065f8eed3db15c63f82800fa96450756674e93c514ae159aea6b3ab9L15) [[3]](diffhunk://#diff-e26b2fda065f8eed3db15c63f82800fa96450756674e93c514ae159aea6b3ab9L24)

These changes collectively modernize the aperture editing experience, making actions more accessible and the UI more maintainable.

---

**References:**
- [[1]](diffhunk://#diff-5f9b454ba0d8674d2efbaa71c55c649ade6467c1085417f686e80e2e28dc2ed6R1-R171) [[2]](diffhunk://#diff-c97b900f419773c58e4f6d3f908ec7f3e2f1982008d35be958124ae2615db55eL1-R6) [[3]](diffhunk://#diff-c97b900f419773c58e4f6d3f908ec7f3e2f1982008d35be958124ae2615db55eL57-R58) [[4]](diffhunk://#diff-c97b900f419773c58e4f6d3f908ec7f3e2f1982008d35be958124ae2615db55eL72-R84) [[5]](diffhunk://#diff-40e4a69b6405a1edf1cb09d6b271a76bd8da3200e5fe6dda1d3cde131e544095R7-R11) [[6]](diffhunk://#diff-40e4a69b6405a1edf1cb09d6b271a76bd8da3200e5fe6dda1d3cde131e544095R20-R23) [[7]](diffhunk://#diff-e26b2fda065f8eed3db15c63f82800fa96450756674e93c514ae159aea6b3ab9L33-R44) [[8]](diffhunk://#diff-24b7bc5f43c02233f11645f35ab2622e528e0ef25be27bfc67fe7504c509f85cL1-R101) [[9]](diffhunk://#diff-5794e5990db4c1597f8f375cc0e26b9320f9cdc73fc3665c4a0c688ed3ade292L13-R33) [[10]](diffhunk://#diff-e26b2fda065f8eed3db15c63f82800fa96450756674e93c514ae159aea6b3ab9L1-L6) [[11]](diffhunk://#diff-e26b2fda065f8eed3db15c63f82800fa96450756674e93c514ae159aea6b3ab9L15) [[12]](diffhunk://#diff-e26b2fda065f8eed3db15c63f82800fa96450756674e93c514ae159aea6b3ab9L24)