### PR TITLE
Add last_modified for aperture entities

### DIFF
--- a/backend/alembic/versions/d3e4f5a6b7c8_add_aperture_last_modified.py
+++ b/backend/alembic/versions/d3e4f5a6b7c8_add_aperture_last_modified.py
@@ -1,0 +1,72 @@
+# -*- Python Version: 3.11 -*-
+"""Add ``last_modified`` to all six aperture-domain tables.
+
+Each row carries its own DB-clock ``last_modified`` stamp. The
+aperture serializer aggregates the max() across the parent aperture,
+its elements, those elements' glazing/frame children, and the
+referenced glazing-type / frame-type catalog rows to expose a single
+per-aperture ``last_modified`` value on the API. Consumers (currently
+the HB Room Builder Rhino plugin) use that aggregate as a coarse
+"has this type been touched?" signal.
+
+See ``docs/plans/260501/aperture-last-modified-timestamp.md`` (§§5.2,
+6.1) for the full design and rationale, especially for why this is
+done as per-table columns rather than a single column on ``apertures``.
+
+Existing rows in production receive ``func.now()`` at migration apply
+time via ``server_default``, so no manual backfill is required.
+
+Revision ID: d3e4f5a6b7c8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-05-01
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d3e4f5a6b7c8"
+down_revision: Union[str, None] = "b2c3d4e5f6a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Tables that participate in the "type definition" aggregation walk.
+# Order is upgrade-add / downgrade-remove order; on upgrade we add to
+# all six, on downgrade we remove from all six. No FK dependencies
+# between these columns, so order is cosmetic.
+_TABLES: tuple[str, ...] = (
+    "apertures",
+    "aperture_elements",
+    "aperture_element_glazing",
+    "aperture_element_frame",
+    "aperture_glazing_types",
+    "aperture_frame_types",
+)
+
+
+def upgrade() -> None:
+    """Upgrade schema — add ``last_modified`` to every aperture-domain table."""
+    for table in _TABLES:
+        op.add_column(
+            table,
+            sa.Column(
+                "last_modified",
+                sa.DateTime(timezone=True),
+                # NOT NULL with server_default ensures every existing
+                # row receives the apply-time clock value, so no
+                # backfill DML is required and the SQLAlchemy model's
+                # nullable=False stays consistent on first deploy.
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema — drop the columns added in upgrade()."""
+    for table in _TABLES:
+        op.drop_column(table, "last_modified")

--- a/backend/db_entities/aperture/_mixins.py
+++ b/backend/db_entities/aperture/_mixins.py
@@ -1,0 +1,27 @@
+# -*- Python Version: 3.11 -*-
+"""Shared SQLAlchemy mixins for the aperture domain."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+
+class LastModifiedMixin:
+    """Adds a DB-clock ``last_modified`` column to a mapped class.
+
+    The aperture catalog endpoint aggregates ``last_modified`` across
+    six related tables (parent aperture + elements + glazing/frame
+    children + glazing-type/frame-type catalog rows) into a single
+    per-aperture wire field. ``func.now()`` is used for both the
+    server default and ``onupdate`` so timestamps are monotonic per
+    row across multi-pod app deployments — the DB clock is the only
+    source of truth.
+    """
+
+    last_modified: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/backend/db_entities/aperture/aperture.py
+++ b/backend/db_entities/aperture/aperture.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING
 
 from database import Base
+from db_entities.aperture._mixins import LastModifiedMixin
 from db_entities.aperture.aperture_element import ApertureElement
 from sqlalchemy import ARRAY, JSON, Float, ForeignKey, Integer, String, TypeDecorator
 from sqlalchemy.orm import Mapped, MappedColumn, relationship
@@ -40,7 +41,7 @@ if TYPE_CHECKING:
     from db_entities.app.project import Project
 
 
-class Aperture(Base):
+class Aperture(LastModifiedMixin, Base):
     __tablename__ = "apertures"
 
     id: Mapped[int] = MappedColumn(Integer, primary_key=True, index=True)

--- a/backend/db_entities/aperture/aperture_element.py
+++ b/backend/db_entities/aperture/aperture_element.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING
 
 from database import Base
+from db_entities.aperture._mixins import LastModifiedMixin
 from db_entities.aperture.aperture_frame import ApertureElementFrame
 from db_entities.aperture.aperture_glazing import ApertureElementGlazing
 from sqlalchemy import JSON, ForeignKey, Integer, String
@@ -13,7 +14,7 @@ if TYPE_CHECKING:
     from db_entities.aperture.aperture import Aperture
 
 
-class ApertureElement(Base):
+class ApertureElement(LastModifiedMixin, Base):
     __tablename__ = "aperture_elements"
 
     id: Mapped[int] = MappedColumn(Integer, primary_key=True, index=True)

--- a/backend/db_entities/aperture/aperture_frame.py
+++ b/backend/db_entities/aperture/aperture_frame.py
@@ -2,12 +2,13 @@
 
 
 from database import Base
+from db_entities.aperture._mixins import LastModifiedMixin
 from db_entities.aperture.frame_type import ApertureFrameType
 from sqlalchemy import ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, MappedColumn, relationship
 
 
-class ApertureElementFrame(Base):
+class ApertureElementFrame(LastModifiedMixin, Base):
     __tablename__ = "aperture_element_frame"
 
     id: Mapped[int] = MappedColumn(Integer, primary_key=True, index=True)

--- a/backend/db_entities/aperture/aperture_glazing.py
+++ b/backend/db_entities/aperture/aperture_glazing.py
@@ -1,12 +1,13 @@
 # -*- Python Version: 3.11 -*-
 
 from database import Base
+from db_entities.aperture._mixins import LastModifiedMixin
 from db_entities.aperture.glazing_type import ApertureGlazingType
 from sqlalchemy import ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, MappedColumn, relationship
 
 
-class ApertureElementGlazing(Base):
+class ApertureElementGlazing(LastModifiedMixin, Base):
     __tablename__ = "aperture_element_glazing"
 
     id: Mapped[int] = MappedColumn(Integer, primary_key=True, index=True)

--- a/backend/db_entities/aperture/frame_type.py
+++ b/backend/db_entities/aperture/frame_type.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING
 
 from database import Base
+from db_entities.aperture._mixins import LastModifiedMixin
 from sqlalchemy import Float, String
 from sqlalchemy.orm import Mapped, MappedColumn, relationship
 
@@ -11,7 +12,7 @@ if TYPE_CHECKING:
     from db_entities.aperture.aperture_frame import ApertureElementFrame
 
 
-class ApertureFrameType(Base):
+class ApertureFrameType(LastModifiedMixin, Base):
     __tablename__ = "aperture_frame_types"
 
     id: Mapped[str] = MappedColumn(String, primary_key=True, index=True)

--- a/backend/db_entities/aperture/glazing_type.py
+++ b/backend/db_entities/aperture/glazing_type.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING
 
 from database import Base
+from db_entities.aperture._mixins import LastModifiedMixin
 from sqlalchemy import Float, String
 from sqlalchemy.orm import Mapped, MappedColumn, relationship
 
@@ -11,7 +12,7 @@ if TYPE_CHECKING:
     from db_entities.aperture.aperture_glazing import ApertureElementGlazing
 
 
-class ApertureGlazingType(Base):
+class ApertureGlazingType(LastModifiedMixin, Base):
     __tablename__ = "aperture_glazing_types"
 
     id: Mapped[str] = MappedColumn(String, primary_key=True, index=True)

--- a/backend/features/aperture/schemas/aperture.py
+++ b/backend/features/aperture/schemas/aperture.py
@@ -3,13 +3,25 @@
 from __future__ import annotations  # Enables forward references
 
 from enum import Enum
+from typing import TYPE_CHECKING
 
 from features.aperture.schemas.aperture_element import ApertureElementSchema
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, PrivateAttr, computed_field
+
+if TYPE_CHECKING:
+    from db_entities.aperture.aperture import Aperture
 
 
 class ApertureSchema(BaseModel):
-    """Base schema for Aperture."""
+    """Base schema for Aperture.
+
+    Exposes a per-aperture ``last_modified`` aggregate (UTC ISO-8601
+    with trailing ``Z``) computed by walking the parent aperture, its
+    elements, and the referenced glazing-type / frame-type catalog
+    rows. The Rhino plugin compares this value byte-for-byte against
+    a stored copy on each block, so the format is part of the wire
+    contract — see ``services/last_modified.py``.
+    """
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -18,6 +30,38 @@ class ApertureSchema(BaseModel):
     row_heights_mm: list[float]
     column_widths_mm: list[float]
     elements: list[ApertureElementSchema]
+
+    # The ``last_modified`` aggregate walks relationships not exposed
+    # as schema fields (``element.glazing.glazing_type``, each
+    # ``frame.frame_type``), so we hold onto the source ORM instance.
+    _orm_aperture: "Aperture | None" = PrivateAttr(default=None)
+
+    @classmethod
+    def model_validate(cls, obj, /, **kwargs):
+        instance = super().model_validate(obj, **kwargs)
+        instance._orm_aperture = obj
+        return instance
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def last_modified(self) -> str:
+        # Deferred import: services/last_modified.py imports the
+        # FrameSide enum from this module, so a top-level import here
+        # would cycle.
+        from features.aperture.services.last_modified import (
+            compute_aperture_effective_last_modified,
+            format_last_modified,
+        )
+
+        if self._orm_aperture is None:
+            raise ValueError(
+                "ApertureSchema.last_modified requires construction via "
+                "model_validate(orm_instance); got a schema with no source "
+                "ORM reference."
+            )
+        return format_last_modified(
+            compute_aperture_effective_last_modified(self._orm_aperture)
+        )
 
 
 class ColumnDeleteRequest(BaseModel):

--- a/backend/features/aperture/services/aperture.py
+++ b/backend/features/aperture/services/aperture.py
@@ -15,6 +15,7 @@ from features.aperture.services.aperture_element import (
 from features.aperture.services.frame_type import get_frame_type_by_id
 from features.aperture.services.glazing_type import get_glazing_type_by_id
 from features.app.services import get_project_by_bt_number
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
@@ -126,11 +127,16 @@ def add_row_to_aperture(
             new_row_index = 0
             aperture.row_heights_mm = [row_height_mm] + aperture.row_heights_mm
 
-            # Shift all existing elements' row_number by +1
+            # Core-level bulk updates historically did not fire
+            # SQLAlchemy's ``onupdate``, so ``last_modified`` is set
+            # explicitly here and at the three other shift sites.
             db.query(ApertureElement).filter(
                 ApertureElement.aperture_id == aperture_id
             ).update(
-                {ApertureElement.row_number: ApertureElement.row_number + 1},
+                {
+                    ApertureElement.row_number: ApertureElement.row_number + 1,
+                    ApertureElement.last_modified: func.now(),
+                },
                 synchronize_session=False,
             )
         else:
@@ -191,11 +197,14 @@ def add_column_to_aperture(
             new_col_index = 0
             aperture.column_widths_mm = [column_width_mm] + aperture.column_widths_mm
 
-            # Shift all existing elements' column_number by +1
+            # Shift all existing elements' column_number by +1.
             db.query(ApertureElement).filter(
                 ApertureElement.aperture_id == aperture_id
             ).update(
-                {ApertureElement.column_number: ApertureElement.column_number + 1},
+                {
+                    ApertureElement.column_number: ApertureElement.column_number + 1,
+                    ApertureElement.last_modified: func.now(),
+                },
                 synchronize_session=False,
             )
         else:
@@ -264,7 +273,10 @@ def delete_row_from_aperture(
             ApertureElement.aperture_id == aperture_id,
             ApertureElement.row_number > row_number,
         ).update(
-            {ApertureElement.row_number: ApertureElement.row_number - 1},
+            {
+                ApertureElement.row_number: ApertureElement.row_number - 1,
+                ApertureElement.last_modified: func.now(),
+            },
             synchronize_session=False,
         )
 
@@ -320,7 +332,10 @@ def delete_column_from_aperture(
             ApertureElement.aperture_id == aperture_id,
             ApertureElement.column_number > column_number,
         ).update(
-            {ApertureElement.column_number: ApertureElement.column_number - 1},
+            {
+                ApertureElement.column_number: ApertureElement.column_number - 1,
+                ApertureElement.last_modified: func.now(),
+            },
             synchronize_session=False,
         )
 

--- a/backend/features/aperture/services/last_modified.py
+++ b/backend/features/aperture/services/last_modified.py
@@ -1,0 +1,94 @@
+# -*- Python Version: 3.11 -*-
+"""Aggregate ``last_modified`` for an aperture's full type definition.
+
+The HB Room Builder Rhino plugin needs a single per-aperture
+"has this type been touched?" timestamp. The "type definition"
+spans six tables (per plan §4):
+
+* the aperture row itself
+* its child element rows
+* each element's glazing child row
+* each element's four frame child rows (top / right / bottom / left)
+* the referenced glazing-type catalog row
+* the referenced frame-type catalog row
+
+Each of those rows carries its own DB-clock ``last_modified`` stamp
+(``server_default=func.now()`` + ``onupdate=func.now()``), so the
+aggregate is a deterministic max() over them at read time. Catalog
+edits propagate through the walk without coupling catalog write
+paths to aperture write paths.
+
+The serialized wire format is committed to ISO-8601 UTC with a
+trailing ``Z`` (e.g. ``"2026-04-28T14:32:00Z"``). The Rhino plugin
+does literal string equality between stored and freshly-fetched
+values, so anything that yields ``"+00:00"`` would silently flag
+every block as stale on first sync.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from db_entities.aperture.aperture import Aperture
+from features.aperture.schemas.aperture import FrameSide
+
+
+def _ensure_aware(dt: datetime) -> datetime:
+    """Defensively attach UTC tzinfo if absent.
+
+    On SQLite (the test backend) ``DateTime(timezone=True)`` columns
+    return naive datetimes — the tz info is dropped on read because
+    SQLite has no native ``timestamptz``. On Postgres (production)
+    the value is already aware. We always assume any naive datetime
+    represents UTC, consistent with how ``func.now()`` writes are
+    stored under ``timestamptz``.
+
+    Without this normalization, ``.astimezone(timezone.utc)`` on the
+    returned aggregate raises ``ValueError`` on the test path while
+    production stays green — exactly the kind of "passes locally,
+    breaks in CI" trap we neutralize at the helper.
+    """
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+def compute_aperture_effective_last_modified(aperture: Aperture) -> datetime:
+    """Return max() ``last_modified`` across the aperture's type definition.
+
+    Walks the aperture row, every loaded element, each element's
+    glazing + glazing-type and four frames + frame-types. Any None
+    children (an unassigned glazing or frame side) are skipped.
+
+    The returned datetime is always tz-aware (UTC). Callers should
+    serialize with ``.isoformat().replace("+00:00", "Z")``.
+    """
+    candidates: list[datetime] = [aperture.last_modified]
+
+    for element in aperture.elements:
+        candidates.append(element.last_modified)
+
+        if element.glazing is not None:
+            candidates.append(element.glazing.last_modified)
+            if element.glazing.glazing_type is not None:
+                candidates.append(element.glazing.glazing_type.last_modified)
+
+        for side in FrameSide:
+            frame = getattr(element, f"frame_{side.value}")
+            if frame is None:
+                continue
+            candidates.append(frame.last_modified)
+            if frame.frame_type is not None:
+                candidates.append(frame.frame_type.last_modified)
+
+    # Filter out any None stamps defensively (e.g. partially-migrated
+    # dev DBs) before normalizing tz info — see _ensure_aware.
+    return max(_ensure_aware(c) for c in candidates if c is not None)
+
+
+def format_last_modified(dt: datetime) -> str:
+    """Format an aware datetime as the committed UTC-with-``Z`` wire format.
+
+    The Rhino plugin compares the stored value on each block against
+    a fresh API value byte-for-byte, so the format MUST be stable —
+    ``"+00:00"`` and ``"Z"`` are both valid ISO-8601 but not byte-equal.
+    """
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/backend/tests/features/aperture/conftest.py
+++ b/backend/tests/features/aperture/conftest.py
@@ -22,6 +22,59 @@ def test_db(session: Session) -> Generator[Session, None, None]:
     yield session
 
 
+def create_aperture_with_element(
+    db: Session,
+    project: Project,
+    name: str,
+    frame_type: ApertureFrameType,
+    glazing_type: ApertureGlazingType,
+) -> Aperture:
+    """Build an aperture with one fully-wired element (4 frames + glazing).
+
+    Lives in conftest so all aperture test modules share one helper
+    instead of redefining (and drifting) their own copies.
+    """
+    aperture = Aperture(
+        name=name,
+        project_id=project.id,
+        row_heights_mm=[1000.0],
+        column_widths_mm=[1200.0],
+    )
+    db.add(aperture)
+    db.flush()
+
+    frames = [
+        ApertureElementFrame(name=f"{name} {side}", frame_type_id=frame_type.id)
+        for side in ("Top", "Right", "Bottom", "Left")
+    ]
+    db.add_all(frames)
+    db.flush()
+
+    glazing = ApertureElementGlazing(
+        name=f"{name} Glazing", glazing_type_id=glazing_type.id
+    )
+    db.add(glazing)
+    db.flush()
+
+    element = ApertureElement(
+        name=f"{name} Element",
+        aperture_id=aperture.id,
+        row_number=1,
+        column_number=1,
+        row_span=1,
+        col_span=1,
+        frame_top_id=frames[0].id,
+        frame_right_id=frames[1].id,
+        frame_bottom_id=frames[2].id,
+        frame_left_id=frames[3].id,
+        glazing_id=glazing.id,
+    )
+    db.add(element)
+    db.commit()
+    db.refresh(aperture)
+    return aperture
+
+
 @pytest.fixture(scope="function")
 def sample_aperture_with_elements(test_db: Session) -> Aperture:
     """Create a sample aperture with elements, frames, and glazing for testing."""

--- a/backend/tests/features/aperture/test_aperture_last_modified.py
+++ b/backend/tests/features/aperture/test_aperture_last_modified.py
@@ -1,0 +1,352 @@
+# -*- Python Version: 3.11 -*-
+"""Tests for the per-aperture ``last_modified`` timestamp feature.
+
+The aperture catalog endpoint exposes a ``last_modified`` ISO-8601 UTC
+timestamp on each aperture. The HB Room Builder Rhino plugin uses this
+as a coarse "has this type been touched?" signal to flag stale block
+geometry. See ``docs/plans/260501/aperture-last-modified-timestamp.md``
+for the full design.
+
+These tests cover three layers:
+
+1. **Route-level** — the JSON payload includes ``last_modified`` in the
+   committed wire format (UTC ISO-8601 with trailing ``Z``).
+2. **Stability** — across reads with no mutations the value is
+   byte-equal; per-aperture mutations on aperture A do not perturb
+   aperture B's timestamp.
+3. **Cascade** — frame-type / glazing-type catalog edits propagate
+   into the aggregate ``last_modified`` of every aperture that
+   references them.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from db_entities.aperture.aperture import Aperture
+from db_entities.aperture.aperture_element import ApertureElement
+from db_entities.aperture.aperture_frame import ApertureElementFrame
+from db_entities.aperture.aperture_glazing import ApertureElementGlazing
+from db_entities.aperture.frame_type import ApertureFrameType
+from db_entities.aperture.glazing_type import ApertureGlazingType
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+# ``Z``-suffixed ISO-8601 UTC, e.g. "2026-04-28T14:32:00Z" or
+# "2026-04-28T14:32:00.123456Z". The Rhino plugin will do literal
+# string equality on this format, so the regex pins it tight.
+_ISO_Z_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$"
+)
+
+
+def _backdate_aperture(db: Session, aperture: Aperture) -> None:
+    """Force every row in this aperture's type definition into the past.
+
+    SQLite resolves ``CURRENT_TIMESTAMP`` to the second, so a naive
+    "snapshot, mutate, assert after > before" sequence is racy unless
+    the baseline is far enough back that the next ``func.now()`` write
+    is guaranteed greater. Backdating one minute is plenty.
+
+    This is preferred over ``time.sleep(1.05)`` because it keeps the
+    test suite tight without compromising what's exercised: the
+    mutation path still goes through ``func.now()`` end-to-end.
+    """
+    past = datetime.now(timezone.utc) - timedelta(minutes=1)
+
+    db.query(Aperture).filter(Aperture.id == aperture.id).update(
+        {Aperture.last_modified: past}
+    )
+    element_ids = [e.id for e in aperture.elements]
+    if element_ids:
+        db.query(ApertureElement).filter(
+            ApertureElement.id.in_(element_ids)
+        ).update({ApertureElement.last_modified: past}, synchronize_session=False)
+
+        glazing_ids = [e.glazing_id for e in aperture.elements if e.glazing_id]
+        if glazing_ids:
+            db.query(ApertureElementGlazing).filter(
+                ApertureElementGlazing.id.in_(glazing_ids)
+            ).update(
+                {ApertureElementGlazing.last_modified: past},
+                synchronize_session=False,
+            )
+
+        frame_ids = [
+            fid
+            for e in aperture.elements
+            for fid in e.frame_ids
+            if fid is not None
+        ]
+        if frame_ids:
+            db.query(ApertureElementFrame).filter(
+                ApertureElementFrame.id.in_(frame_ids)
+            ).update(
+                {ApertureElementFrame.last_modified: past},
+                synchronize_session=False,
+            )
+
+    db.query(ApertureFrameType).update(
+        {ApertureFrameType.last_modified: past}, synchronize_session=False
+    )
+    db.query(ApertureGlazingType).update(
+        {ApertureGlazingType.last_modified: past}, synchronize_session=False
+    )
+    db.commit()
+
+
+def _get_aperture_payload(client: TestClient, bt_number: str, name: str) -> dict:
+    """Pull the named aperture out of the get-apertures-as-json route payload."""
+    response = client.get(f"/aperture/get-apertures-as-json/{bt_number}")
+    assert response.status_code == 200
+    apertures = json.loads(response.json()["apertures"])
+    assert name in apertures, f"aperture {name!r} missing from payload"
+    return apertures[name]
+
+
+def test_route_payload_includes_last_modified(
+    client: TestClient,
+    test_db: Session,
+    sample_aperture_with_elements: Aperture,
+) -> None:
+    """RED-anchor: each aperture record exposes ``last_modified``.
+
+    Acceptance criterion #1 from the request: every record in the
+    response includes a ``last_modified`` field.
+    """
+    aperture_data = _get_aperture_payload(client, "AP001", "Test Aperture")
+    assert "last_modified" in aperture_data
+
+
+def test_route_last_modified_is_iso8601_z_format(
+    client: TestClient,
+    test_db: Session,
+    sample_aperture_with_elements: Aperture,
+) -> None:
+    """The wire format is UTC ISO-8601 with trailing ``Z``.
+
+    Acceptance criterion #5: format is consistent and parseable. We
+    commit to ``Z`` (not ``+00:00``) because the Rhino plugin will do
+    literal string equality between stored and freshly-fetched values.
+    """
+    aperture_data = _get_aperture_payload(client, "AP001", "Test Aperture")
+    last_modified = aperture_data["last_modified"]
+
+    assert isinstance(last_modified, str)
+    assert _ISO_Z_RE.match(last_modified), (
+        f"last_modified {last_modified!r} is not in the expected "
+        f"UTC ISO-8601-with-Z format"
+    )
+    # And round-trips through datetime parsing as UTC.
+    parsed = datetime.fromisoformat(last_modified.replace("Z", "+00:00"))
+    assert parsed.tzinfo is not None
+    assert parsed.utcoffset() == timezone.utc.utcoffset(parsed)
+
+
+def test_route_last_modified_stable_across_reads(
+    client: TestClient,
+    test_db: Session,
+    sample_aperture_with_elements: Aperture,
+) -> None:
+    """Acceptance criterion #3: stable across reads when nothing changes.
+
+    Three back-to-back GETs must produce byte-equal ``last_modified``
+    values. If they don't, the Rhino plugin would flag every block as
+    stale on every sync.
+    """
+    payload_1 = _get_aperture_payload(client, "AP001", "Test Aperture")
+    payload_2 = _get_aperture_payload(client, "AP001", "Test Aperture")
+    payload_3 = _get_aperture_payload(client, "AP001", "Test Aperture")
+
+    assert payload_1["last_modified"] == payload_2["last_modified"]
+    assert payload_2["last_modified"] == payload_3["last_modified"]
+
+
+def test_route_last_modified_unaffected_by_unrelated_aperture_mutation(
+    client: TestClient,
+    test_db: Session,
+    sample_aperture_with_elements: Aperture,
+) -> None:
+    """Acceptance criterion #4: per-record granularity.
+
+    Mutating aperture B must not change aperture A's ``last_modified``.
+    """
+    # Create a second aperture in the same project.
+    project = sample_aperture_with_elements.project
+    frame_type = test_db.query(ApertureFrameType).first()
+    glazing_type = test_db.query(ApertureGlazingType).first()
+    assert frame_type is not None and glazing_type is not None
+
+    from tests.features.aperture.conftest import create_aperture_with_element
+
+    create_aperture_with_element(
+        test_db,
+        project,
+        name="Other Aperture",
+        frame_type=frame_type,
+        glazing_type=glazing_type,
+    )
+
+    a_before = _get_aperture_payload(client, "AP001", "Test Aperture")["last_modified"]
+
+    # Mutate the OTHER aperture's name. This is the simplest mutation
+    # available via the public API.
+    other = (
+        test_db.query(Aperture)
+        .filter(Aperture.name == "Other Aperture")
+        .one()
+    )
+    response = client.patch(
+        f"/aperture/update-aperture-name/{other.id}",
+        json={"new_name": "Other Aperture (renamed)"},
+    )
+    assert response.status_code == 200
+
+    a_after = _get_aperture_payload(client, "AP001", "Test Aperture")["last_modified"]
+    assert a_before == a_after, (
+        "mutating an unrelated aperture must not change this aperture's "
+        "last_modified"
+    )
+
+
+def test_route_last_modified_advances_on_mutation(
+    client: TestClient,
+    test_db: Session,
+    sample_aperture_with_elements: Aperture,
+) -> None:
+    """Acceptance criterion #2: any mutation bumps ``last_modified``."""
+    aperture = sample_aperture_with_elements
+    _backdate_aperture(test_db, aperture)
+    before = _get_aperture_payload(client, "AP001", "Test Aperture")["last_modified"]
+
+    response = client.patch(
+        f"/aperture/update-aperture-name/{aperture.id}",
+        json={"new_name": "Test Aperture (renamed)"},
+    )
+    assert response.status_code == 200
+
+    after = _get_aperture_payload(client, "AP001", "Test Aperture (renamed)")[
+        "last_modified"
+    ]
+    assert after > before, f"before={before} after={after}"
+
+
+def test_route_last_modified_advances_on_frame_type_catalog_edit(
+    client: TestClient,
+    test_db: Session,
+    sample_aperture_with_elements: Aperture,
+) -> None:
+    """Catalog cascade: editing a referenced ``ApertureFrameType`` row
+    must advance the aggregate ``last_modified`` of every aperture
+    that references it.
+    """
+    _backdate_aperture(test_db, sample_aperture_with_elements)
+    before = _get_aperture_payload(client, "AP001", "Test Aperture")["last_modified"]
+
+    frame_type = test_db.query(ApertureFrameType).first()
+    assert frame_type is not None
+    frame_type.u_value_w_m2k = frame_type.u_value_w_m2k + 0.1
+    test_db.commit()
+
+    after = _get_aperture_payload(client, "AP001", "Test Aperture")["last_modified"]
+    assert after > before, f"before={before} after={after}"
+
+
+def test_route_last_modified_advances_on_glazing_type_catalog_edit(
+    client: TestClient,
+    test_db: Session,
+    sample_aperture_with_elements: Aperture,
+) -> None:
+    """Catalog cascade — symmetric to the frame-type test."""
+    _backdate_aperture(test_db, sample_aperture_with_elements)
+    before = _get_aperture_payload(client, "AP001", "Test Aperture")["last_modified"]
+
+    glazing_type = test_db.query(ApertureGlazingType).first()
+    assert glazing_type is not None
+    glazing_type.u_value_w_m2k = glazing_type.u_value_w_m2k + 0.1
+    test_db.commit()
+
+    after = _get_aperture_payload(client, "AP001", "Test Aperture")["last_modified"]
+    assert after > before, f"before={before} after={after}"
+
+
+def test_sibling_element_last_modified_moves_on_start_row_insert(
+    test_db: Session,
+    sample_aperture_with_elements: Aperture,
+) -> None:
+    """Sibling-shift correctness (plan §5.3 edge case 3 / §6.3).
+
+    The START-insert path uses a Core-level ``Query.update`` to shift
+    sibling ``row_number``\\ s. The plan flagged this as a possible
+    blind spot for ``onupdate``; the service patch sets
+    ``last_modified: func.now()`` explicitly in the update dict.
+    """
+    from features.aperture.schemas.aperture import InsertPosition
+    from features.aperture.services.aperture import add_row_to_aperture
+
+    aperture = sample_aperture_with_elements
+    _backdate_aperture(test_db, aperture)
+
+    pre_existing_element = (
+        test_db.query(ApertureElement)
+        .filter(ApertureElement.aperture_id == aperture.id)
+        .order_by(ApertureElement.id.asc())
+        .first()
+    )
+    assert pre_existing_element is not None
+    before = pre_existing_element.last_modified
+
+    add_row_to_aperture(
+        test_db, aperture.id, row_height_mm=500.0, position=InsertPosition.START
+    )
+
+    test_db.refresh(pre_existing_element)
+    after = pre_existing_element.last_modified
+
+    # SQLite drops tzinfo on read from a timezone=True column; normalize.
+    if before.tzinfo is None:
+        before = before.replace(tzinfo=timezone.utc)
+    if after.tzinfo is None:
+        after = after.replace(tzinfo=timezone.utc)
+
+    assert after > before, f"before={before} after={after}"
+
+
+@pytest.mark.parametrize(
+    "model_path,column_name",
+    [
+        ("db_entities.aperture.aperture.Aperture", "last_modified"),
+        ("db_entities.aperture.aperture_element.ApertureElement", "last_modified"),
+        (
+            "db_entities.aperture.aperture_glazing.ApertureElementGlazing",
+            "last_modified",
+        ),
+        ("db_entities.aperture.aperture_frame.ApertureElementFrame", "last_modified"),
+        ("db_entities.aperture.glazing_type.ApertureGlazingType", "last_modified"),
+        ("db_entities.aperture.frame_type.ApertureFrameType", "last_modified"),
+    ],
+)
+def test_all_six_entities_have_last_modified_column(
+    test_db: Session, model_path: str, column_name: str
+) -> None:
+    """Lowest-layer schema check.
+
+    All six entities involved in the "type definition" (per plan §4)
+    must expose a ``last_modified`` column on the ORM model so the
+    serializer's aggregation walk has something to read from.
+    """
+    module_path, _, attr = model_path.rpartition(".")
+    module = __import__(module_path, fromlist=[attr])
+    model = getattr(module, attr)
+
+    assert column_name in model.__table__.columns, (
+        f"{model.__name__} is missing required column {column_name!r}"
+    )
+    column = model.__table__.columns[column_name]
+    assert not column.nullable, (
+        f"{model.__name__}.{column_name} must be NOT NULL "
+        f"(server_default = func.now() ensures existing rows have a value)"
+    )

--- a/backend/tests/features/aperture/test_get_apertures_as_json_route.py
+++ b/backend/tests/features/aperture/test_get_apertures_as_json_route.py
@@ -4,9 +4,6 @@
 import json
 
 from db_entities.aperture.aperture import Aperture
-from db_entities.aperture.aperture_element import ApertureElement
-from db_entities.aperture.aperture_frame import ApertureElementFrame
-from db_entities.aperture.aperture_glazing import ApertureElementGlazing
 from db_entities.aperture.frame_type import ApertureFrameType
 from db_entities.aperture.glazing_type import ApertureGlazingType
 from db_entities.app.project import Project
@@ -15,6 +12,7 @@ from fastapi.testclient import TestClient
 from features.auth.services import get_password_hash
 from main import app
 from sqlalchemy.orm import Session
+from tests.features.aperture.conftest import create_aperture_with_element
 
 
 def _create_project(db: Session, bt_number: str) -> Project:
@@ -37,58 +35,6 @@ def _create_project(db: Session, bt_number: str) -> Project:
     return project
 
 
-def _create_aperture_with_element(
-    db: Session,
-    project: Project,
-    name: str,
-    frame_type: ApertureFrameType,
-    glazing_type: ApertureGlazingType,
-) -> Aperture:
-    aperture = Aperture(
-        name=name,
-        project_id=project.id,
-        row_heights_mm=[1000.0],
-        column_widths_mm=[1200.0],
-    )
-    db.add(aperture)
-    db.flush()
-
-    frame_top = ApertureElementFrame(name=f"{name} Top", frame_type_id=frame_type.id)
-    frame_right = ApertureElementFrame(
-        name=f"{name} Right", frame_type_id=frame_type.id
-    )
-    frame_bottom = ApertureElementFrame(
-        name=f"{name} Bottom", frame_type_id=frame_type.id
-    )
-    frame_left = ApertureElementFrame(name=f"{name} Left", frame_type_id=frame_type.id)
-    db.add_all([frame_top, frame_right, frame_bottom, frame_left])
-    db.flush()
-
-    glazing = ApertureElementGlazing(
-        name=f"{name} Glazing", glazing_type_id=glazing_type.id
-    )
-    db.add(glazing)
-    db.flush()
-
-    element = ApertureElement(
-        name=f"{name} Element",
-        aperture_id=aperture.id,
-        row_number=1,
-        column_number=1,
-        row_span=1,
-        col_span=1,
-        frame_top_id=frame_top.id,
-        frame_right_id=frame_right.id,
-        frame_bottom_id=frame_bottom.id,
-        frame_left_id=frame_left.id,
-        glazing_id=glazing.id,
-    )
-    db.add(element)
-    db.commit()
-    db.refresh(aperture)
-    return aperture
-
-
 def test_get_apertures_as_json_route_returns_json_string(
     client: TestClient,
     test_db: Session,
@@ -108,6 +54,15 @@ def test_get_apertures_as_json_route_returns_json_string(
     assert aperture_data["name"] == "Test Aperture"
     assert "elements" in aperture_data
     assert len(aperture_data["elements"]) == 1
+
+    # Per-aperture ``last_modified`` is part of the wire contract for
+    # the HB Room Builder Rhino plugin (see plan §1). Detailed format
+    # / cascade / stability assertions live in
+    # ``test_aperture_last_modified.py``; the presence check here
+    # guards against accidental schema regressions on this route.
+    assert "last_modified" in aperture_data
+    assert isinstance(aperture_data["last_modified"], str)
+    assert aperture_data["last_modified"].endswith("Z")
 
     element = aperture_data["elements"][0]
     assert "glazing" in element
@@ -139,7 +94,7 @@ def test_get_apertures_as_json_route_multiple_apertures(
     assert frame_type is not None
     assert glazing_type is not None
 
-    _create_aperture_with_element(
+    create_aperture_with_element(
         test_db,
         project,
         name="Second Aperture",


### PR DESCRIPTION
Introduce per-row DB-clock `last_modified` across the aperture domain: add an Alembic migration to create the column on six tables, a LastModifiedMixin for models, and apply the mixin to aperture, element, glazing, frame, glazing_type and frame_type models. Add services to compute and format a per-aperture aggregate `last_modified` (UTC ISO-8601 with trailing Z) and expose it as a computed field on the Aperture schema. Ensure bulk update paths explicitly set `last_modified` (use func.now()) to avoid onupdate blind spots. Add test helpers, route adjustments, and comprehensive tests covering wire format, stability, mutation/cascade behavior, and schema presence. Migration uses server_default=func.now() so existing rows are backfilled at apply time.